### PR TITLE
feat: map VPButton to Button

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,6 +12,7 @@ module.exports = {
   rules: {
     "prettier/prettier": "error",
     "vue/component-name-in-template-casing": ["error", "PascalCase"],
+    "vue/multi-word-component-names": "off",
     "require-await": "error",
     "no-return-await": "error",
     "no-case-declarations": "off",

--- a/.storybook/mock/VPButton.vue
+++ b/.storybook/mock/VPButton.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import {computed} from "vue";
+const EXTERNAL_URL_RE = /^(?:[a-z]+:|\/\/)/i;
+
+interface Props {
+  tag?: string;
+  size?: "medium" | "big";
+  theme?: "brand" | "alt" | "sponsor";
+  text: string;
+  href?: string;
+  target?: string;
+  rel?: string;
+}
+const props = withDefaults(defineProps<Props>(), {
+  size: "medium",
+  theme: "brand"
+});
+
+const isExternal = computed(() => props.href && EXTERNAL_URL_RE.test(props.href));
+
+const component = computed(() => {
+  return props.tag || props.href ? "a" : "button";
+});
+</script>
+
+<template>
+  <component
+    :is="component"
+    class="VPButton"
+    :class="[size, theme]"
+    :href="href ? href : undefined"
+    :target="props.target ?? (isExternal ? '_blank' : undefined)"
+    :rel="props.rel ?? (isExternal ? 'noreferrer' : undefined)"
+  >
+    {{ text }}
+  </component>
+</template>
+
+<style scoped>
+.VPButton {
+  display: inline-block;
+  border: 1px solid transparent;
+  text-align: center;
+  font-weight: 600;
+  white-space: nowrap;
+  transition:
+    color 0.25s,
+    border-color 0.25s,
+    background-color 0.25s;
+}
+
+.VPButton:active {
+  transition:
+    color 0.1s,
+    border-color 0.1s,
+    background-color 0.1s;
+}
+
+.VPButton.medium {
+  border-radius: 20px;
+  padding: 0 20px;
+  line-height: 38px;
+  font-size: 14px;
+}
+
+.VPButton.big {
+  border-radius: 24px;
+  padding: 0 24px;
+  line-height: 46px;
+  font-size: 16px;
+}
+
+.VPButton.brand {
+  border-color: var(--vp-button-brand-border);
+  color: var(--vp-button-brand-text);
+  background-color: var(--vp-button-brand-bg);
+}
+
+.VPButton.brand:hover {
+  border-color: var(--vp-button-brand-hover-border);
+  color: var(--vp-button-brand-hover-text);
+  background-color: var(--vp-button-brand-hover-bg);
+}
+
+.VPButton.brand:active {
+  border-color: var(--vp-button-brand-active-border);
+  color: var(--vp-button-brand-active-text);
+  background-color: var(--vp-button-brand-active-bg);
+}
+
+.VPButton.alt {
+  border-color: var(--vp-button-alt-border);
+  color: var(--vp-button-alt-text);
+  background-color: var(--vp-button-alt-bg);
+}
+
+.VPButton.alt:hover {
+  border-color: var(--vp-button-alt-hover-border);
+  color: var(--vp-button-alt-hover-text);
+  background-color: var(--vp-button-alt-hover-bg);
+}
+
+.VPButton.alt:active {
+  border-color: var(--vp-button-alt-active-border);
+  color: var(--vp-button-alt-active-text);
+  background-color: var(--vp-button-alt-active-bg);
+}
+
+.VPButton.sponsor {
+  border-color: var(--vp-button-sponsor-border);
+  color: var(--vp-button-sponsor-text);
+  background-color: var(--vp-button-sponsor-bg);
+}
+
+.VPButton.sponsor:hover {
+  border-color: var(--vp-button-sponsor-hover-border);
+  color: var(--vp-button-sponsor-hover-text);
+  background-color: var(--vp-button-sponsor-hover-bg);
+}
+
+.VPButton.sponsor:active {
+  border-color: var(--vp-button-sponsor-active-border);
+  color: var(--vp-button-sponsor-active-text);
+  background-color: var(--vp-button-sponsor-active-bg);
+}
+</style>

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -14,8 +14,10 @@ import "vitepress/dist/client/theme-default/styles/components/vp-doc.css";
 import "vitepress/dist/client/theme-default/styles/components/vp-sponsor.css";
 import "../docs/.vitepress/theme/style.css";
 import LazyLoadObserver from "../docs/.vitepress/theme/directives/lazyLoadObserver";
+import VPButton from "./mock/VPButton.vue";
 
 setup((app) => {
+  app.component("VPButton", VPButton);
   app.directive("lazyload-observer", LazyLoadObserver);
 });
 

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -8,6 +8,7 @@ import ApiAnchorQuery from "./molecules/api-anchor/ApiAnchorQuery.vue";
 import ApiList from "./molecules/api-list/ApiList.vue";
 import GithubContributors from "./organisms/github-contributors/GithubContributors.vue";
 import LazyLoadObserver from "./directives/lazyLoadObserver";
+import Button from "./molecules/button/Button.vue";
 
 export default {
   extends: DefaultTheme,
@@ -20,6 +21,8 @@ export default {
     app.component("ApiList", ApiList);
     app.component("ApiAnchorQuery", ApiAnchorQuery);
     app.component("GithubContributors", GithubContributors);
+    // eslint-disable-next-line vue/no-reserved-component-names
+    app.component("Button", Button);
     app.directive("lazyload-observer", LazyLoadObserver);
   }
 } satisfies Theme;

--- a/docs/.vitepress/theme/molecules/button-badge/ButtonBadge.spec.ts
+++ b/docs/.vitepress/theme/molecules/button-badge/ButtonBadge.spec.ts
@@ -11,12 +11,17 @@ describe("<ButtonBadge>", () => {
         showTitle: true,
         width: 60,
         bgColor: "gray-lighter",
-        color: "blue",
         blur: 0,
         textSize: "xxs",
-        shadow: "",
-        padding: 5,
-        fontWeight: "400"
+        padding: 5
+      },
+      global: {
+        directives: {
+          lazyloadObserver: {
+            mounted() {},
+            updated() {}
+          }
+        }
       }
     });
 
@@ -35,12 +40,17 @@ describe("<ButtonBadge>", () => {
         showTitle: false,
         width: 60,
         bgColor: "gray-lighter",
-        color: "blue",
         blur: 0,
         textSize: "xxs",
-        shadow: "",
-        padding: 5,
-        fontWeight: "400"
+        padding: 5
+      },
+      global: {
+        directives: {
+          lazyloadObserver: {
+            mounted() {},
+            updated() {}
+          }
+        }
       }
     });
 
@@ -56,12 +66,17 @@ describe("<ButtonBadge>", () => {
         showTitle: true,
         width: 60,
         bgColor: "gray-lighter",
-        color: "blue",
         blur: 5,
         textSize: "xxs",
-        shadow: "",
-        padding: 5,
-        fontWeight: "400"
+        padding: 5
+      },
+      global: {
+        directives: {
+          lazyloadObserver: {
+            mounted() {},
+            updated() {}
+          }
+        }
       }
     });
 

--- a/docs/.vitepress/theme/molecules/button-badge/ButtonBadges.spec.ts
+++ b/docs/.vitepress/theme/molecules/button-badge/ButtonBadges.spec.ts
@@ -8,7 +8,15 @@ function getFixture(props: any = {}) {
   ];
 
   return render(ButtonBadges, {
-    props: {items, ...props}
+    props: {items, ...props},
+    global: {
+      directives: {
+        lazyloadObserver: {
+          mounted() {},
+          updated() {}
+        }
+      }
+    }
   });
 }
 

--- a/docs/.vitepress/theme/molecules/button/Button.spec.ts
+++ b/docs/.vitepress/theme/molecules/button/Button.spec.ts
@@ -1,0 +1,30 @@
+import {render} from "@testing-library/vue";
+import Button from "./Button.vue";
+import VPButton from "../../../../../.storybook/mock/VPButton.vue";
+
+describe("<Button>", () => {
+  it("should render the Button with default properties and verify presence of elements and attributes", () => {
+    const {container} = render(Button, {
+      props: {},
+      slots: {
+        default: "Text"
+      },
+      global: {
+        stubs: {
+          VPButton: VPButton
+        }
+      }
+    });
+
+    expect(container).toMatchInlineSnapshot(`
+      <div>
+        <button
+          class="VPButton medium brand"
+          data-v-cd8c0a71=""
+        >
+          Text
+        </button>
+      </div>
+    `);
+  });
+});

--- a/docs/.vitepress/theme/molecules/button/Button.stories.ts
+++ b/docs/.vitepress/theme/molecules/button/Button.stories.ts
@@ -1,0 +1,45 @@
+import type {Meta, StoryObj} from "@storybook/vue3";
+import Button from "./Button.vue";
+
+const meta = {
+  title: "Button",
+  component: Button,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered"
+  },
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["medium", "big"],
+      default: "medium"
+    },
+    theme: {
+      control: "select",
+      options: ["brand", "alt", "sponsor"],
+      default: "brand"
+    },
+    text: {
+      control: "text",
+      default: "Default"
+    }
+  },
+  render: (args) => ({
+    components: {Button},
+    setup() {
+      return {args};
+    },
+    template: '<Button v-bind="args">{{args.text}}</Button>'
+  })
+} satisfies Meta<typeof Button> & {argTypes: {text: any}};
+
+export default meta;
+type Story = StoryObj<typeof meta> & {args: {text: string}};
+
+export const Default: Story = {
+  args: {
+    size: "medium",
+    theme: "brand",
+    text: "Default"
+  }
+};

--- a/docs/.vitepress/theme/molecules/button/Button.vue
+++ b/docs/.vitepress/theme/molecules/button/Button.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import {computed, useSlots} from "vue";
+
+export interface ButtonProps {
+  tag?: string;
+  size?: "medium" | "big";
+  theme?: "brand" | "alt" | "sponsor";
+  href?: string;
+  target?: string;
+  rel?: string;
+}
+
+const props = withDefaults(defineProps<ButtonProps>(), {
+  size: "medium",
+  theme: "brand"
+});
+
+const slots = useSlots();
+const text = computed(() => {
+  return String(slots.default!()[0].children).trim();
+});
+</script>
+<template>
+  <VPButton v-bind="props" :text="text" />
+</template>

--- a/docs/.vitepress/theme/molecules/contributors/ContributorItems.spec.ts
+++ b/docs/.vitepress/theme/molecules/contributors/ContributorItems.spec.ts
@@ -9,7 +9,15 @@ describe("<ContributorItems>", () => {
 
   it("renders ButtonBadges when items are present", () => {
     render(ContributorItems, {
-      props: {items}
+      props: {items},
+      global: {
+        directives: {
+          lazyloadObserver: {
+            mounted() {},
+            updated() {}
+          }
+        }
+      }
     });
     expect(screen.getByText(items[0].login)).toBeInTheDocument();
     expect(screen.getByText(items[1].login)).toBeInTheDocument();
@@ -17,7 +25,15 @@ describe("<ContributorItems>", () => {
 
   it("does not render ButtonBadges when items are empty", () => {
     render(ContributorItems, {
-      props: {items: []}
+      props: {items: []},
+      global: {
+        directives: {
+          lazyloadObserver: {
+            mounted() {},
+            updated() {}
+          }
+        }
+      }
     });
     expect(screen.queryByText(items[0]?.login)).not.toBeInTheDocument();
     expect(screen.queryByText(items[1]?.login)).not.toBeInTheDocument();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,10 +19,10 @@ export default defineConfig({
       enabled: true,
       thresholds: {
         autoUpdate: true,
-        statements: 91.86,
-        branches: 87.2,
+        statements: 92.14,
+        branches: 87.35,
         functions: 94.11,
-        lines: 91.86
+        lines: 92.14
       },
       include: ["**/*.{ts,vue}"],
       exclude: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `VPButton` Vue component for customizable button functionality.
  - Added new storybook configuration for the `Button` component.

- **Bug Fixes**
  - Improved testing setup for `GithubContributors.spec.ts` by switching to `@testing-library/vue`.

- **Refactor**
  - Updated ESLint configuration to disable `vue/multi-word-component-names` rule.
  - Simplified mock and test setup in `GithubContributors.spec.ts`.

- **Tests**
  - Added global directives for `lazyloadObserver` in multiple component tests to enhance lazy loading testing.
  - Increased coverage thresholds in `vitest.config.ts`.

- **Documentation**
  - New `Button.vue` component added with TypeScript setup in the documentation theme.
  - Improved component registration process for storybook and Vue app setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->